### PR TITLE
destination_id Query Param for Duplicate Node

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -123,9 +123,9 @@ func (c *client) DeleteNode(ctx context.Context, id uuid.UUID) (err error) {
 }
 
 func (c *client) DuplicateNode(ctx context.Context, source uuid.UUID, destination uuid.UUID, suffix string) (uuid.UUID, error) {
-	request := rest.Post("nodes/{node}/duplicate{?dstParentNodeId,label_suffix}").
+	request := rest.Post("nodes/{node}/duplicate{?destination_id,label_suffix}").
 		Assign("node", source).
-		Assign("dstParentNodeId", destination).
+		Assign("destination_id", destination).
 		Assign("label_suffix", suffix).
 		SetHeader("Accept", "application/json")
 

--- a/rest/example/main.go
+++ b/rest/example/main.go
@@ -5,22 +5,33 @@ import (
 	"fmt"
 
 	hierarchy "github.com/SKF/go-hierarchy-v2-client/rest"
-
 	"github.com/SKF/go-rest-utility/client"
 	"github.com/SKF/go-rest-utility/client/auth"
 	"github.com/SKF/go-utility/v2/auth/secretsmanagerauth"
 	"github.com/SKF/go-utility/v2/stages"
+
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	dd_http "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 )
 
-const serviceName = "example-service"
-const clientID = "2e51739d-61e8-4c34-bdbc-de0cd4b53dfe" //random uuid in example
+const (
+	awsProfile  = "example_profile"
+	clientID    = "2e51739d-61e8-4c34-bdbc-de0cd4b53dfe" //random uuid in example
+	serviceName = "example-service"
+)
+
+var awsRegion = "eu-west-1"
 
 func main() {
 	ctx := context.Background()
 
-	sess, err := session.NewSession()
+	sess, err := session.NewSessionWithOptions(
+		session.Options{
+			Config:  aws.Config{Region: aws.String(awsRegion)},
+			Profile: awsProfile,
+		},
+	)
 	if err != nil {
 		panic(err)
 	}
@@ -35,7 +46,7 @@ func main() {
 				ServiceName:              serviceName,
 				AWSSession:               sess,
 				AWSSecretsManagerAccount: "633888256817",
-				AWSSecretsManagerRegion:  "eu-west-1",
+				AWSSecretsManagerRegion:  awsRegion,
 				SecretKey:                "user-credentials/" + serviceName,
 				Stage:                    stages.StageSandbox,
 			},


### PR DESCRIPTION
- Change query param name from `dstParentNodeId` to `destination_id`
- Update `rest/example/main.go` with additional configurations and examples