### PR TITLE
Bump supported Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SKF/go-hierarchy-v2-client
 
-go 1.18
+go 1.19
 
 require (
 	github.com/SKF/go-rest-utility v0.13.1


### PR DESCRIPTION
Updates to the minimum supported Go version to 1.19.